### PR TITLE
Trim strings in JSONSerializer.toJSON()

### DIFF
--- a/src/main/java/net/sf/json/JSONSerializer.java
+++ b/src/main/java/net/sf/json/JSONSerializer.java
@@ -129,6 +129,7 @@ public class JSONSerializer {
     */
    private static JSON toJSON( String string, JsonConfig jsonConfig ) {
       JSON json = null;
+      string = string.trim();
       if( string.startsWith( "[" ) ){
          json = JSONArray.fromObject( string, jsonConfig );
       }else if( string.startsWith( "{" ) ){


### PR DESCRIPTION
Allow leading and trailing whitespace in toJSON() by removing it before trying to guess the JSON object type.