### PR TITLE
Modernize package info

### DIFF
--- a/src/main/java/net/sf/ezmorph/array/package-info.java
+++ b/src/main/java/net/sf/ezmorph/array/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Morphers for arrays.
+ */
+package net.sf.ezmorph.array;

--- a/src/main/java/net/sf/ezmorph/array/package.html
+++ b/src/main/java/net/sf/ezmorph/array/package.html
@@ -1,8 +1,0 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
-<html>
-<head>
-</head>
-<body bgcolor="white">
-<p>Morphers for arrays.</p>
-</body>
-</html>

--- a/src/main/java/net/sf/ezmorph/bean/package-info.java
+++ b/src/main/java/net/sf/ezmorph/bean/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Morphers for JavaBeans and DynaBeans.
+ */
+package net.sf.ezmorph.bean;

--- a/src/main/java/net/sf/ezmorph/bean/package.html
+++ b/src/main/java/net/sf/ezmorph/bean/package.html
@@ -1,8 +1,0 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
-<html>
-<head>
-</head>
-<body bgcolor="white">
-<p>Morphers for JavaBeans and DynaBeans.</p>
-</body>
-</html>

--- a/src/main/java/net/sf/ezmorph/object/package-info.java
+++ b/src/main/java/net/sf/ezmorph/object/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Morphers for Object types.
+ */
+package net.sf.ezmorph.object;

--- a/src/main/java/net/sf/ezmorph/object/package.html
+++ b/src/main/java/net/sf/ezmorph/object/package.html
@@ -1,8 +1,0 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
-<html>
-<head>
-</head>
-<body bgcolor="white">
-<p>Morphers for Object types.</p>
-</body>
-</html>

--- a/src/main/java/net/sf/ezmorph/package-info.java
+++ b/src/main/java/net/sf/ezmorph/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Base package
+ */
+package net.sf.ezmorph;

--- a/src/main/java/net/sf/ezmorph/package.html
+++ b/src/main/java/net/sf/ezmorph/package.html
@@ -1,8 +1,0 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
-<html>
-<head>
-</head>
-<body bgcolor="white">
-<p></p>
-</body>
-</html>

--- a/src/main/java/net/sf/ezmorph/primitive/package-info.java
+++ b/src/main/java/net/sf/ezmorph/primitive/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Morphers for primitive types.
+ */
+package net.sf.ezmorph.primitive;

--- a/src/main/java/net/sf/ezmorph/primitive/package.html
+++ b/src/main/java/net/sf/ezmorph/primitive/package.html
@@ -1,8 +1,0 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
-<html>
-<head>
-</head>
-<body bgcolor="white">
-<p>Morphers for primitive types.</p>
-</body>
-</html>

--- a/src/main/java/net/sf/ezmorph/test/package-info.java
+++ b/src/main/java/net/sf/ezmorph/test/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Assertions for testing array equiality.
+ */
+package net.sf.ezmorph.test;

--- a/src/main/java/net/sf/ezmorph/test/package.html
+++ b/src/main/java/net/sf/ezmorph/test/package.html
@@ -1,8 +1,0 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
-<html>
-<head>
-</head>
-<body bgcolor="white">
-<p>Assertions for testing array equiality.</p>
-</body>
-</html>

--- a/src/main/java/net/sf/json/filters/package-info.java
+++ b/src/main/java/net/sf/json/filters/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Support for custom serialization
+ */
+package net.sf.json.filters;

--- a/src/main/java/net/sf/json/filters/package.html
+++ b/src/main/java/net/sf/json/filters/package.html
@@ -1,8 +1,0 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
-<html>
-<head>
-</head>
-<body bgcolor="white">
-<p>Support for custom serialization</p>
-</body>
-</html>

--- a/src/main/java/net/sf/json/groovy/package-info.java
+++ b/src/main/java/net/sf/json/groovy/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Groovy support
+ */
+package net.sf.json.groovy;

--- a/src/main/java/net/sf/json/groovy/package.html
+++ b/src/main/java/net/sf/json/groovy/package.html
@@ -1,8 +1,0 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
-<html>
-<head>
-</head>
-<body bgcolor="white">
-<p>Groovy support</p>
-</body>
-</html>

--- a/src/main/java/net/sf/json/package-info.java
+++ b/src/main/java/net/sf/json/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * The core of the library
+ */
+package net.sf.json;

--- a/src/main/java/net/sf/json/package.html
+++ b/src/main/java/net/sf/json/package.html
@@ -1,8 +1,0 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
-<html>
-<head>
-</head>
-<body bgcolor="white">
-<p>The core of the library</p>
-</body>
-</html>

--- a/src/main/java/net/sf/json/processors/package-info.java
+++ b/src/main/java/net/sf/json/processors/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Support for custom serialization
+ */
+package net.sf.json.processors;

--- a/src/main/java/net/sf/json/processors/package.html
+++ b/src/main/java/net/sf/json/processors/package.html
@@ -1,8 +1,0 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
-<html>
-<head>
-</head>
-<body bgcolor="white">
-<p>Support for custom serialization</p>
-</body>
-</html>

--- a/src/main/java/net/sf/json/regexp/package-info.java
+++ b/src/main/java/net/sf/json/regexp/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Regexp utilities
+ */
+package net.sf.json.regexp;

--- a/src/main/java/net/sf/json/regexp/package.html
+++ b/src/main/java/net/sf/json/regexp/package.html
@@ -1,8 +1,0 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
-<html>
-<head>
-</head>
-<body bgcolor="white">
-<p>Regexp utilities</p>
-</body>
-</html>

--- a/src/main/java/net/sf/json/test/package-info.java
+++ b/src/main/java/net/sf/json/test/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Testing utilities
+ */
+package net.sf.json.test;

--- a/src/main/java/net/sf/json/test/package.html
+++ b/src/main/java/net/sf/json/test/package.html
@@ -1,8 +1,0 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
-<html>
-<head>
-</head>
-<body bgcolor="white">
-<p>Testing utilities</p>
-</body>
-</html>

--- a/src/main/java/net/sf/json/util/package-info.java
+++ b/src/main/java/net/sf/json/util/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Miscellaneous utilities
+ */
+package net.sf.json.util;

--- a/src/main/java/net/sf/json/util/package.html
+++ b/src/main/java/net/sf/json/util/package.html
@@ -1,8 +1,0 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
-<html>
-<head>
-</head>
-<body bgcolor="white">
-<p>Miscelaneous utilities</p>
-</body>
-</html>

--- a/src/main/java/net/sf/json/xml/package-info.java
+++ b/src/main/java/net/sf/json/xml/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Utilities for transforming JSON to XML and back.
+ */
+package net.sf.json.xml;

--- a/src/main/java/net/sf/json/xml/package.html
+++ b/src/main/java/net/sf/json/xml/package.html
@@ -1,8 +1,0 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
-<html>
-<head>
-</head>
-<body bgcolor="white">
-<p>Utilities for trasforming JSON to XML and back.</p>
-</body>
-</html>


### PR DESCRIPTION
package-info.java: "This file is new in JDK 5.0, and is preferred over package.html."—[javadoc - The Java API Documentation Generator](https://docs.oracle.com/javase/8/docs/technotes/tools/unix/javadoc.html#packagecomment)

### Testing done

CI build