### PR TITLE
Remove usage of `NestableRuntimeException`

### DIFF
--- a/src/main/java/net/sf/ezmorph/MorphException.java
+++ b/src/main/java/net/sf/ezmorph/MorphException.java
@@ -16,8 +16,6 @@
 
 package net.sf.ezmorph;
 
-import org.apache.commons.lang.exception.NestableRuntimeException;
-
 /**
  * A <strong>MorphException</strong> indicates that a call to
  * <code>Morpher.morph()</code> has failed to complete successfully.<br>
@@ -25,7 +23,7 @@ import org.apache.commons.lang.exception.NestableRuntimeException;
  *
  * @author Andres Almiray <a href="mailto:aalmiray@users.sourceforge.net">aalmiray@users.sourceforge.net</a>
  */
-public class MorphException extends NestableRuntimeException {
+public class MorphException extends RuntimeException {
     private static final long serialVersionUID = -540093801787033824L;
 
     // ----------------------------------------------------------- Constructors

--- a/src/main/java/net/sf/json/JSONException.java
+++ b/src/main/java/net/sf/json/JSONException.java
@@ -15,15 +15,13 @@
  */
 package net.sf.json;
 
-import org.apache.commons.lang.exception.NestableRuntimeException;
-
 /**
  * The JSONException is thrown when things are amiss.
  *
  * @author JSON.org
  * @version 4
  */
-public class JSONException extends NestableRuntimeException {
+public class JSONException extends RuntimeException {
     private static final long serialVersionUID = 6995087065217051815L;
 
     public JSONException() {

--- a/src/main/java/net/sf/json/regexp/Perl5RegexpMatcher.java
+++ b/src/main/java/net/sf/json/regexp/Perl5RegexpMatcher.java
@@ -16,7 +16,6 @@
 
 package net.sf.json.regexp;
 
-import org.apache.commons.lang.exception.NestableRuntimeException;
 import org.apache.oro.text.regex.MalformedPatternException;
 import org.apache.oro.text.regex.Pattern;
 import org.apache.oro.text.regex.PatternMatcher;
@@ -45,7 +44,7 @@ public class Perl5RegexpMatcher implements RegexpMatcher {
                 this.pattern = compiler.compile(pattern, Perl5Compiler.READ_ONLY_MASK);
             }
         } catch (MalformedPatternException mpe) {
-            throw new NestableRuntimeException(mpe);
+            throw new RuntimeException(mpe);
         }
     }
 


### PR DESCRIPTION
This has been nestable in the Java Platform since Java 1.4.

### Testing done

`mvn clean verify`