### PR TITLE
[JENKINS-67344] Poor performance of `UpdateSite.getData`

### DIFF
--- a/src/main/java/net/sf/json/JSONObject.java
+++ b/src/main/java/net/sf/json/JSONObject.java
@@ -943,7 +943,7 @@ public final class JSONObject extends AbstractJSON implements JSON, Map<String, 
             String key;
             Object value;
 
-            if (tokener.matches("null.*")) {
+            if (tokener.startsWith("null")) {
                 fireObjectStartEvent(jsonConfig);
                 fireObjectEndEvent(jsonConfig);
                 return new JSONObject(true);

--- a/src/main/java/net/sf/json/util/JSONTokener.java
+++ b/src/main/java/net/sf/json/util/JSONTokener.java
@@ -110,6 +110,15 @@ public class JSONTokener {
         return RegexpUtils.getMatcher(pattern).matches(str);
     }
 
+    public boolean startsWith(String pattern) {
+        int patternLength = pattern.length();
+        if (length() - this.myIndex < patternLength) {
+            return false;
+        }
+        String str = this.mySource.substring(this.myIndex, this.myIndex + patternLength);
+        return str.startsWith(pattern);
+    }
+
     /**
      * Determine if the source string still contains characters that next() can
      * consume.

--- a/src/main/java/net/sf/json/util/JSONTokener.java
+++ b/src/main/java/net/sf/json/util/JSONTokener.java
@@ -110,13 +110,13 @@ public class JSONTokener {
         return RegexpUtils.getMatcher(pattern).matches(str);
     }
 
-    public boolean startsWith(String pattern) {
-        int patternLength = pattern.length();
+    public boolean startsWith(String prefix) {
+        int patternLength = prefix.length();
         if (length() - this.myIndex < patternLength) {
             return false;
         }
         String str = this.mySource.substring(this.myIndex, this.myIndex + patternLength);
-        return str.startsWith(pattern);
+        return str.startsWith(prefix);
     }
 
     /**

--- a/src/main/java/net/sf/json/util/JSONTokener.java
+++ b/src/main/java/net/sf/json/util/JSONTokener.java
@@ -111,11 +111,11 @@ public class JSONTokener {
     }
 
     public boolean startsWith(String prefix) {
-        int patternLength = prefix.length();
-        if (length() - this.myIndex < patternLength) {
+        int prefixLength = prefix.length();
+        if (length() - this.myIndex < prefixLength) {
             return false;
         }
-        String str = this.mySource.substring(this.myIndex, this.myIndex + patternLength);
+        String str = this.mySource.substring(this.myIndex, this.myIndex + prefixLength);
         return str.startsWith(prefix);
     }
 

--- a/src/test/java/net/sf/json/util/TestJSONTokener.java
+++ b/src/test/java/net/sf/json/util/TestJSONTokener.java
@@ -74,6 +74,20 @@ public class TestJSONTokener extends TestCase {
         }
     }
 
+    public void testStartsWith() {
+        assertFalse(new JSONTokener("").startsWith("null"));
+        assertFalse(new JSONTokener("n").startsWith("null"));
+        assertFalse(new JSONTokener("nu").startsWith("null"));
+        assertFalse(new JSONTokener("nul").startsWith("null"));
+        assertTrue(new JSONTokener("null").startsWith("null"));
+        assertTrue(new JSONTokener("nulll").startsWith("null"));
+        assertFalse(new JSONTokener("nn").startsWith("null"));
+        assertFalse(new JSONTokener("nnu").startsWith("null"));
+        assertFalse(new JSONTokener("nnul").startsWith("null"));
+        assertFalse(new JSONTokener("nnull").startsWith("null"));
+        assertFalse(new JSONTokener("nnulll").startsWith("null"));
+    }
+
     public void testReset() {
         JSONTokener tok = new JSONTokener("abc");
         tok.next();


### PR DESCRIPTION
Profiling showed that while regex compilation was indeed a problem, it wasn't the bottleneck. The real bottleneck was repeatedly copying a massive string just to search a few characters in it. Fixed by copying just the portion of the string we need to search. See flame graphs before and after.

![before](https://github.com/jenkinsci/json-lib/assets/29850/4ef3e19c-ea10-443b-9ba3-fb548dbe5623)

![after](https://github.com/jenkinsci/json-lib/assets/29850/639408aa-ff28-48fc-bda0-732c5cece146)

### Next steps

If merged and deployed to Jenkins users successfully, I will try to propose this upstream at https://github.com/kordamp/json-lib.

### Testing done

Tested against the real Jenkins Update Center JSON file; execution time went from about 8 seconds to about 0.4 seconds consistently. Tested interactively in Jenkins as well; the "Refresh" button on the plugin update page is now bounded by download time, not CPU time, and for me goes from about 12 seconds to about 5 seconds.