### PR TITLE
Remove `commons-httpclient` test dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -215,12 +215,6 @@
       <optional>true</optional>
     </dependency>
     <dependency>
-      <groupId>commons-httpclient</groupId>
-      <artifactId>commons-httpclient</artifactId>
-      <version>3.1-jenkins-3</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.xmlunit</groupId>
       <artifactId>xmlunit-legacy</artifactId>
       <version>2.9.1</version>


### PR DESCRIPTION
This test dependency appears to be unused. Since it triggers security scanners, best to rip it out.

### Testing done

`mvn clean verify`