### PR TITLE
Revert part of #33

### DIFF
--- a/src/main/java/net/sf/json/JSONObject.java
+++ b/src/main/java/net/sf/json/JSONObject.java
@@ -1412,7 +1412,7 @@ public final class JSONObject extends AbstractJSON implements JSON, Map<String, 
     /**
      * The Map where the JSONObject's properties are kept.
      */
-    private Map<String, Object> properties;
+    private Map properties;
 
     /**
      * Construct an empty JSONObject.
@@ -1799,7 +1799,7 @@ public final class JSONObject extends AbstractJSON implements JSON, Map<String, 
     }
 
     @Override
-    public Set<Map.Entry<String, Object>> entrySet() {
+    public Set entrySet() {
         return Collections.unmodifiableSet(properties.entrySet());
     }
 


### PR DESCRIPTION
Revert part of #33 since this was causing compilation errors at least in Jenkins and possibly elsewhere (since the change was to a public method). Since I don't want this release to be disruptive it is simplest to go back to the old code without type parameters for now.

### Testing done

`mvn clean verify`