### PR TITLE
Reduce usages of `EqualsBuilder` and `HashCodeBuilder`

### DIFF
--- a/src/main/java/net/sf/ezmorph/array/BooleanArrayMorpher.java
+++ b/src/main/java/net/sf/ezmorph/array/BooleanArrayMorpher.java
@@ -17,10 +17,9 @@
 package net.sf.ezmorph.array;
 
 import java.lang.reflect.Array;
+import java.util.Objects;
 import net.sf.ezmorph.MorphException;
 import net.sf.ezmorph.primitive.BooleanMorpher;
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
 
 /**
  * Morphs an array to a boolean[].
@@ -57,12 +56,10 @@ public final class BooleanArrayMorpher extends AbstractArrayMorpher {
         }
 
         BooleanArrayMorpher other = (BooleanArrayMorpher) obj;
-        EqualsBuilder builder = new EqualsBuilder();
         if (isUseDefault() && other.isUseDefault()) {
-            builder.append(getDefaultValue(), other.getDefaultValue());
-            return builder.isEquals();
+            return Objects.equals(getDefaultValue(), other.getDefaultValue());
         } else if (!isUseDefault() && !other.isUseDefault()) {
-            return builder.isEquals();
+            return true;
         } else {
             return false;
         }
@@ -74,11 +71,10 @@ public final class BooleanArrayMorpher extends AbstractArrayMorpher {
 
     @Override
     public int hashCode() {
-        HashCodeBuilder builder = new HashCodeBuilder();
         if (isUseDefault()) {
-            builder.append(getDefaultValue());
+            return Objects.hashCode(getDefaultValue());
         }
-        return builder.toHashCode();
+        return 17;
     }
 
     @Override

--- a/src/main/java/net/sf/ezmorph/array/BooleanObjectArrayMorpher.java
+++ b/src/main/java/net/sf/ezmorph/array/BooleanObjectArrayMorpher.java
@@ -17,10 +17,9 @@
 package net.sf.ezmorph.array;
 
 import java.lang.reflect.Array;
+import java.util.Objects;
 import net.sf.ezmorph.MorphException;
 import net.sf.ezmorph.primitive.BooleanMorpher;
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
 
 /**
  * Morphs an array to a Boolean[].
@@ -57,12 +56,10 @@ public final class BooleanObjectArrayMorpher extends AbstractArrayMorpher {
         }
 
         BooleanObjectArrayMorpher other = (BooleanObjectArrayMorpher) obj;
-        EqualsBuilder builder = new EqualsBuilder();
         if (isUseDefault() && other.isUseDefault()) {
-            builder.append(getDefaultValue(), other.getDefaultValue());
-            return builder.isEquals();
+            return Objects.equals(getDefaultValue(), other.getDefaultValue());
         } else if (!isUseDefault() && !other.isUseDefault()) {
-            return builder.isEquals();
+            return true;
         } else {
             return false;
         }
@@ -74,11 +71,10 @@ public final class BooleanObjectArrayMorpher extends AbstractArrayMorpher {
 
     @Override
     public int hashCode() {
-        HashCodeBuilder builder = new HashCodeBuilder();
         if (isUseDefault()) {
-            builder.append(getDefaultValue());
+            return Objects.hashCode(getDefaultValue());
         }
-        return builder.toHashCode();
+        return 17;
     }
 
     @Override

--- a/src/main/java/net/sf/ezmorph/array/ByteArrayMorpher.java
+++ b/src/main/java/net/sf/ezmorph/array/ByteArrayMorpher.java
@@ -17,10 +17,9 @@
 package net.sf.ezmorph.array;
 
 import java.lang.reflect.Array;
+import java.util.Objects;
 import net.sf.ezmorph.MorphException;
 import net.sf.ezmorph.primitive.ByteMorpher;
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
 
 /**
  * Morphs an array to a byte[].
@@ -57,12 +56,10 @@ public final class ByteArrayMorpher extends AbstractArrayMorpher {
         }
 
         ByteArrayMorpher other = (ByteArrayMorpher) obj;
-        EqualsBuilder builder = new EqualsBuilder();
         if (isUseDefault() && other.isUseDefault()) {
-            builder.append(getDefaultValue(), other.getDefaultValue());
-            return builder.isEquals();
+            return Objects.equals(getDefaultValue(), other.getDefaultValue());
         } else if (!isUseDefault() && !other.isUseDefault()) {
-            return builder.isEquals();
+            return true;
         } else {
             return false;
         }
@@ -74,11 +71,10 @@ public final class ByteArrayMorpher extends AbstractArrayMorpher {
 
     @Override
     public int hashCode() {
-        HashCodeBuilder builder = new HashCodeBuilder();
         if (isUseDefault()) {
-            builder.append(getDefaultValue());
+            return Objects.hashCode(getDefaultValue());
         }
-        return builder.toHashCode();
+        return 17;
     }
 
     @Override

--- a/src/main/java/net/sf/ezmorph/array/CharArrayMorpher.java
+++ b/src/main/java/net/sf/ezmorph/array/CharArrayMorpher.java
@@ -17,10 +17,9 @@
 package net.sf.ezmorph.array;
 
 import java.lang.reflect.Array;
+import java.util.Objects;
 import net.sf.ezmorph.MorphException;
 import net.sf.ezmorph.primitive.CharMorpher;
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
 
 /**
  * Morphs an array to a char[].
@@ -57,12 +56,10 @@ public final class CharArrayMorpher extends AbstractArrayMorpher {
         }
 
         CharArrayMorpher other = (CharArrayMorpher) obj;
-        EqualsBuilder builder = new EqualsBuilder();
         if (isUseDefault() && other.isUseDefault()) {
-            builder.append(getDefaultValue(), other.getDefaultValue());
-            return builder.isEquals();
+            return Objects.equals(getDefaultValue(), other.getDefaultValue());
         } else if (!isUseDefault() && !other.isUseDefault()) {
-            return builder.isEquals();
+            return true;
         } else {
             return false;
         }
@@ -77,11 +74,10 @@ public final class CharArrayMorpher extends AbstractArrayMorpher {
 
     @Override
     public int hashCode() {
-        HashCodeBuilder builder = new HashCodeBuilder();
         if (isUseDefault()) {
-            builder.append(getDefaultValue());
+            return Objects.hashCode(getDefaultValue());
         }
-        return builder.toHashCode();
+        return 17;
     }
 
     @Override

--- a/src/main/java/net/sf/ezmorph/array/CharacterObjectArrayMorpher.java
+++ b/src/main/java/net/sf/ezmorph/array/CharacterObjectArrayMorpher.java
@@ -17,10 +17,9 @@
 package net.sf.ezmorph.array;
 
 import java.lang.reflect.Array;
+import java.util.Objects;
 import net.sf.ezmorph.MorphException;
 import net.sf.ezmorph.primitive.CharMorpher;
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
 
 /**
  * Morphs an array to a Character[].
@@ -57,12 +56,10 @@ public final class CharacterObjectArrayMorpher extends AbstractArrayMorpher {
         }
 
         CharacterObjectArrayMorpher other = (CharacterObjectArrayMorpher) obj;
-        EqualsBuilder builder = new EqualsBuilder();
         if (isUseDefault() && other.isUseDefault()) {
-            builder.append(getDefaultValue(), other.getDefaultValue());
-            return builder.isEquals();
+            return Objects.equals(getDefaultValue(), other.getDefaultValue());
         } else if (!isUseDefault() && !other.isUseDefault()) {
-            return builder.isEquals();
+            return true;
         } else {
             return false;
         }
@@ -74,11 +71,10 @@ public final class CharacterObjectArrayMorpher extends AbstractArrayMorpher {
 
     @Override
     public int hashCode() {
-        HashCodeBuilder builder = new HashCodeBuilder();
         if (isUseDefault()) {
-            builder.append(getDefaultValue());
+            return Objects.hashCode(getDefaultValue());
         }
-        return builder.toHashCode();
+        return 17;
     }
 
     @Override

--- a/src/main/java/net/sf/ezmorph/array/DoubleArrayMorpher.java
+++ b/src/main/java/net/sf/ezmorph/array/DoubleArrayMorpher.java
@@ -17,10 +17,9 @@
 package net.sf.ezmorph.array;
 
 import java.lang.reflect.Array;
+import java.util.Objects;
 import net.sf.ezmorph.MorphException;
 import net.sf.ezmorph.primitive.DoubleMorpher;
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
 
 /**
  * Morphs an array to a double[].
@@ -57,12 +56,10 @@ public final class DoubleArrayMorpher extends AbstractArrayMorpher {
         }
 
         DoubleArrayMorpher other = (DoubleArrayMorpher) obj;
-        EqualsBuilder builder = new EqualsBuilder();
         if (isUseDefault() && other.isUseDefault()) {
-            builder.append(getDefaultValue(), other.getDefaultValue());
-            return builder.isEquals();
+            return Objects.equals(getDefaultValue(), other.getDefaultValue());
         } else if (!isUseDefault() && !other.isUseDefault()) {
-            return builder.isEquals();
+            return true;
         } else {
             return false;
         }
@@ -77,11 +74,10 @@ public final class DoubleArrayMorpher extends AbstractArrayMorpher {
 
     @Override
     public int hashCode() {
-        HashCodeBuilder builder = new HashCodeBuilder();
         if (isUseDefault()) {
-            builder.append(getDefaultValue());
+            return Objects.hashCode(getDefaultValue());
         }
-        return builder.toHashCode();
+        return 17;
     }
 
     @Override

--- a/src/main/java/net/sf/ezmorph/array/FloatArrayMorpher.java
+++ b/src/main/java/net/sf/ezmorph/array/FloatArrayMorpher.java
@@ -17,10 +17,9 @@
 package net.sf.ezmorph.array;
 
 import java.lang.reflect.Array;
+import java.util.Objects;
 import net.sf.ezmorph.MorphException;
 import net.sf.ezmorph.primitive.FloatMorpher;
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
 
 /**
  * Morphs an array to a float[].
@@ -57,12 +56,10 @@ public final class FloatArrayMorpher extends AbstractArrayMorpher {
         }
 
         FloatArrayMorpher other = (FloatArrayMorpher) obj;
-        EqualsBuilder builder = new EqualsBuilder();
         if (isUseDefault() && other.isUseDefault()) {
-            builder.append(getDefaultValue(), other.getDefaultValue());
-            return builder.isEquals();
+            return Objects.equals(getDefaultValue(), other.getDefaultValue());
         } else if (!isUseDefault() && !other.isUseDefault()) {
-            return builder.isEquals();
+            return true;
         } else {
             return false;
         }
@@ -77,11 +74,10 @@ public final class FloatArrayMorpher extends AbstractArrayMorpher {
 
     @Override
     public int hashCode() {
-        HashCodeBuilder builder = new HashCodeBuilder();
         if (isUseDefault()) {
-            builder.append(getDefaultValue());
+            return Objects.hashCode(getDefaultValue());
         }
-        return builder.toHashCode();
+        return 17;
     }
 
     @Override

--- a/src/main/java/net/sf/ezmorph/array/IntArrayMorpher.java
+++ b/src/main/java/net/sf/ezmorph/array/IntArrayMorpher.java
@@ -17,10 +17,9 @@
 package net.sf.ezmorph.array;
 
 import java.lang.reflect.Array;
+import java.util.Objects;
 import net.sf.ezmorph.MorphException;
 import net.sf.ezmorph.primitive.IntMorpher;
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
 
 /**
  * Morphs an array to a int[].
@@ -57,12 +56,10 @@ public final class IntArrayMorpher extends AbstractArrayMorpher {
         }
 
         IntArrayMorpher other = (IntArrayMorpher) obj;
-        EqualsBuilder builder = new EqualsBuilder();
         if (isUseDefault() && other.isUseDefault()) {
-            builder.append(getDefaultValue(), other.getDefaultValue());
-            return builder.isEquals();
+            return Objects.equals(getDefaultValue(), other.getDefaultValue());
         } else if (!isUseDefault() && !other.isUseDefault()) {
-            return builder.isEquals();
+            return true;
         } else {
             return false;
         }
@@ -77,11 +74,10 @@ public final class IntArrayMorpher extends AbstractArrayMorpher {
 
     @Override
     public int hashCode() {
-        HashCodeBuilder builder = new HashCodeBuilder();
         if (isUseDefault()) {
-            builder.append(getDefaultValue());
+            return Objects.hashCode(getDefaultValue());
         }
-        return builder.toHashCode();
+        return 17;
     }
 
     @Override

--- a/src/main/java/net/sf/ezmorph/array/LongArrayMorpher.java
+++ b/src/main/java/net/sf/ezmorph/array/LongArrayMorpher.java
@@ -17,10 +17,9 @@
 package net.sf.ezmorph.array;
 
 import java.lang.reflect.Array;
+import java.util.Objects;
 import net.sf.ezmorph.MorphException;
 import net.sf.ezmorph.primitive.LongMorpher;
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
 
 /**
  * Morphs an array to a long[].
@@ -57,12 +56,10 @@ public final class LongArrayMorpher extends AbstractArrayMorpher {
         }
 
         LongArrayMorpher other = (LongArrayMorpher) obj;
-        EqualsBuilder builder = new EqualsBuilder();
         if (isUseDefault() && other.isUseDefault()) {
-            builder.append(getDefaultValue(), other.getDefaultValue());
-            return builder.isEquals();
+            return Objects.equals(getDefaultValue(), other.getDefaultValue());
         } else if (!isUseDefault() && !other.isUseDefault()) {
-            return builder.isEquals();
+            return true;
         } else {
             return false;
         }
@@ -77,11 +74,10 @@ public final class LongArrayMorpher extends AbstractArrayMorpher {
 
     @Override
     public int hashCode() {
-        HashCodeBuilder builder = new HashCodeBuilder();
         if (isUseDefault()) {
-            builder.append(getDefaultValue());
+            return Objects.hashCode(getDefaultValue());
         }
-        return builder.toHashCode();
+        return 17;
     }
 
     @Override

--- a/src/main/java/net/sf/ezmorph/array/ObjectArrayMorpher.java
+++ b/src/main/java/net/sf/ezmorph/array/ObjectArrayMorpher.java
@@ -18,9 +18,9 @@ package net.sf.ezmorph.array;
 
 import java.lang.reflect.Array;
 import java.lang.reflect.Method;
+import java.util.Objects;
 import net.sf.ezmorph.MorphException;
 import net.sf.ezmorph.Morpher;
-import org.apache.commons.lang.builder.HashCodeBuilder;
 
 /**
  * Morphs an array to another array using a Morpher.
@@ -65,7 +65,7 @@ public final class ObjectArrayMorpher extends AbstractArrayMorpher {
 
     @Override
     public int hashCode() {
-        return new HashCodeBuilder().append(morpher).toHashCode();
+        return Objects.hashCode(morpher);
     }
 
     @Override

--- a/src/main/java/net/sf/ezmorph/array/ShortArrayMorpher.java
+++ b/src/main/java/net/sf/ezmorph/array/ShortArrayMorpher.java
@@ -17,10 +17,9 @@
 package net.sf.ezmorph.array;
 
 import java.lang.reflect.Array;
+import java.util.Objects;
 import net.sf.ezmorph.MorphException;
 import net.sf.ezmorph.primitive.ShortMorpher;
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
 
 /**
  * Morphs an array to a short[].
@@ -57,12 +56,10 @@ public final class ShortArrayMorpher extends AbstractArrayMorpher {
         }
 
         ShortArrayMorpher other = (ShortArrayMorpher) obj;
-        EqualsBuilder builder = new EqualsBuilder();
         if (isUseDefault() && other.isUseDefault()) {
-            builder.append(getDefaultValue(), other.getDefaultValue());
-            return builder.isEquals();
+            return Objects.equals(getDefaultValue(), other.getDefaultValue());
         } else if (!isUseDefault() && !other.isUseDefault()) {
-            return builder.isEquals();
+            return true;
         } else {
             return false;
         }
@@ -77,11 +74,10 @@ public final class ShortArrayMorpher extends AbstractArrayMorpher {
 
     @Override
     public int hashCode() {
-        HashCodeBuilder builder = new HashCodeBuilder();
         if (isUseDefault()) {
-            builder.append(getDefaultValue());
+            return Objects.hashCode(getDefaultValue());
         }
-        return builder.toHashCode();
+        return 17;
     }
 
     @Override

--- a/src/main/java/net/sf/ezmorph/object/BigDecimalMorpher.java
+++ b/src/main/java/net/sf/ezmorph/object/BigDecimalMorpher.java
@@ -18,9 +18,8 @@ package net.sf.ezmorph.object;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.util.Objects;
 import net.sf.ezmorph.MorphException;
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
 
 /**
  * Morphs to a BigDecimal.
@@ -56,12 +55,10 @@ public final class BigDecimalMorpher extends AbstractObjectMorpher {
         }
 
         BigDecimalMorpher other = (BigDecimalMorpher) obj;
-        EqualsBuilder builder = new EqualsBuilder();
         if (isUseDefault() && other.isUseDefault()) {
-            builder.append(getDefaultValue(), other.getDefaultValue());
-            return builder.isEquals();
+            return Objects.equals(getDefaultValue(), other.getDefaultValue());
         } else if (!isUseDefault() && !other.isUseDefault()) {
-            return builder.isEquals();
+            return true;
         } else {
             return false;
         }
@@ -76,11 +73,10 @@ public final class BigDecimalMorpher extends AbstractObjectMorpher {
 
     @Override
     public int hashCode() {
-        HashCodeBuilder builder = new HashCodeBuilder();
         if (isUseDefault()) {
-            builder.append(getDefaultValue());
+            return Objects.hashCode(getDefaultValue());
         }
-        return builder.toHashCode();
+        return 17;
     }
 
     @Override

--- a/src/main/java/net/sf/ezmorph/object/BigIntegerMorpher.java
+++ b/src/main/java/net/sf/ezmorph/object/BigIntegerMorpher.java
@@ -19,9 +19,8 @@ package net.sf.ezmorph.object;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Locale;
+import java.util.Objects;
 import net.sf.ezmorph.MorphException;
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
 
 /**
  * Morphs to a BigInteger.
@@ -57,12 +56,10 @@ public final class BigIntegerMorpher extends AbstractObjectMorpher {
         }
 
         BigIntegerMorpher other = (BigIntegerMorpher) obj;
-        EqualsBuilder builder = new EqualsBuilder();
         if (isUseDefault() && other.isUseDefault()) {
-            builder.append(getDefaultValue(), other.getDefaultValue());
-            return builder.isEquals();
+            return Objects.equals(getDefaultValue(), other.getDefaultValue());
         } else if (!isUseDefault() && !other.isUseDefault()) {
-            return builder.isEquals();
+            return true;
         } else {
             return false;
         }
@@ -77,11 +74,10 @@ public final class BigIntegerMorpher extends AbstractObjectMorpher {
 
     @Override
     public int hashCode() {
-        HashCodeBuilder builder = new HashCodeBuilder();
         if (isUseDefault()) {
-            builder.append(getDefaultValue());
+            return Objects.hashCode(getDefaultValue());
         }
-        return builder.toHashCode();
+        return 17;
     }
 
     @Override

--- a/src/main/java/net/sf/ezmorph/object/BooleanObjectMorpher.java
+++ b/src/main/java/net/sf/ezmorph/object/BooleanObjectMorpher.java
@@ -16,9 +16,8 @@
 
 package net.sf.ezmorph.object;
 
+import java.util.Objects;
 import net.sf.ezmorph.MorphException;
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
 
 /**
  * Morphs to a Boolean.
@@ -54,12 +53,10 @@ public final class BooleanObjectMorpher extends AbstractObjectMorpher {
         }
 
         BooleanObjectMorpher other = (BooleanObjectMorpher) obj;
-        EqualsBuilder builder = new EqualsBuilder();
         if (isUseDefault() && other.isUseDefault()) {
-            builder.append(getDefaultValue(), other.getDefaultValue());
-            return builder.isEquals();
+            return Objects.equals(getDefaultValue(), other.getDefaultValue());
         } else if (!isUseDefault() && !other.isUseDefault()) {
-            return builder.isEquals();
+            return true;
         } else {
             return false;
         }
@@ -74,11 +71,10 @@ public final class BooleanObjectMorpher extends AbstractObjectMorpher {
 
     @Override
     public int hashCode() {
-        HashCodeBuilder builder = new HashCodeBuilder();
         if (isUseDefault()) {
-            builder.append(getDefaultValue());
+            return Objects.hashCode(getDefaultValue());
         }
-        return builder.toHashCode();
+        return 17;
     }
 
     @Override

--- a/src/main/java/net/sf/ezmorph/object/CharacterObjectMorpher.java
+++ b/src/main/java/net/sf/ezmorph/object/CharacterObjectMorpher.java
@@ -16,9 +16,8 @@
 
 package net.sf.ezmorph.object;
 
+import java.util.Objects;
 import net.sf.ezmorph.MorphException;
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
 
 /**
  * Morphs to a Character.
@@ -54,12 +53,10 @@ public final class CharacterObjectMorpher extends AbstractObjectMorpher {
         }
 
         CharacterObjectMorpher other = (CharacterObjectMorpher) obj;
-        EqualsBuilder builder = new EqualsBuilder();
         if (isUseDefault() && other.isUseDefault()) {
-            builder.append(getDefaultValue(), other.getDefaultValue());
-            return builder.isEquals();
+            return Objects.equals(getDefaultValue(), other.getDefaultValue());
         } else if (!isUseDefault() && !other.isUseDefault()) {
-            return builder.isEquals();
+            return true;
         } else {
             return false;
         }
@@ -74,11 +71,10 @@ public final class CharacterObjectMorpher extends AbstractObjectMorpher {
 
     @Override
     public int hashCode() {
-        HashCodeBuilder builder = new HashCodeBuilder();
         if (isUseDefault()) {
-            builder.append(getDefaultValue());
+            return Objects.hashCode(getDefaultValue());
         }
-        return builder.toHashCode();
+        return 17;
     }
 
     @Override

--- a/src/main/java/net/sf/ezmorph/object/MapToDateMorpher.java
+++ b/src/main/java/net/sf/ezmorph/object/MapToDateMorpher.java
@@ -19,9 +19,8 @@ package net.sf.ezmorph.object;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.Map;
+import java.util.Objects;
 import net.sf.ezmorph.MorphException;
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
 
 /**
  * Morphs a Map into a Date.<br>
@@ -58,12 +57,10 @@ public class MapToDateMorpher extends AbstractObjectMorpher {
         }
 
         MapToDateMorpher other = (MapToDateMorpher) obj;
-        EqualsBuilder builder = new EqualsBuilder();
         if (isUseDefault() && other.isUseDefault()) {
-            builder.append(getDefaultValue(), other.getDefaultValue());
-            return builder.isEquals();
+            return Objects.equals(getDefaultValue(), other.getDefaultValue());
         } else if (!isUseDefault() && !other.isUseDefault()) {
-            return builder.isEquals();
+            return true;
         } else {
             return false;
         }
@@ -78,11 +75,10 @@ public class MapToDateMorpher extends AbstractObjectMorpher {
 
     @Override
     public int hashCode() {
-        HashCodeBuilder builder = new HashCodeBuilder();
         if (isUseDefault()) {
-            builder.append(getDefaultValue());
+            return Objects.hashCode(getDefaultValue());
         }
-        return builder.toHashCode();
+        return 17;
     }
 
     @Override

--- a/src/main/java/net/sf/ezmorph/object/ObjectListMorpher.java
+++ b/src/main/java/net/sf/ezmorph/object/ObjectListMorpher.java
@@ -20,9 +20,9 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 import net.sf.ezmorph.MorphException;
 import net.sf.ezmorph.Morpher;
-import org.apache.commons.lang.builder.HashCodeBuilder;
 
 /**
  * Morphs a List to another List using a Morpher.
@@ -71,7 +71,7 @@ public final class ObjectListMorpher extends AbstractObjectMorpher {
 
     @Override
     public int hashCode() {
-        return new HashCodeBuilder().append(morpher).toHashCode();
+        return Objects.hashCode(morpher);
     }
 
     @Override

--- a/src/main/java/net/sf/ezmorph/primitive/BooleanMorpher.java
+++ b/src/main/java/net/sf/ezmorph/primitive/BooleanMorpher.java
@@ -16,9 +16,8 @@
 
 package net.sf.ezmorph.primitive;
 
+import java.util.Objects;
 import net.sf.ezmorph.MorphException;
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
 
 /**
  * Morphs to a boolean.
@@ -54,12 +53,10 @@ public final class BooleanMorpher extends AbstractPrimitiveMorpher {
         }
 
         BooleanMorpher other = (BooleanMorpher) obj;
-        EqualsBuilder builder = new EqualsBuilder();
         if (isUseDefault() && other.isUseDefault()) {
-            builder.append(getDefaultValue(), other.getDefaultValue());
-            return builder.isEquals();
+            return Objects.equals(getDefaultValue(), other.getDefaultValue());
         } else if (!isUseDefault() && !other.isUseDefault()) {
-            return builder.isEquals();
+            return true;
         } else {
             return false;
         }
@@ -74,11 +71,10 @@ public final class BooleanMorpher extends AbstractPrimitiveMorpher {
 
     @Override
     public int hashCode() {
-        HashCodeBuilder builder = new HashCodeBuilder();
         if (isUseDefault()) {
-            builder.append(getDefaultValue());
+            return Objects.hashCode(getDefaultValue());
         }
-        return builder.toHashCode();
+        return 17;
     }
 
     /**

--- a/src/main/java/net/sf/ezmorph/primitive/ByteMorpher.java
+++ b/src/main/java/net/sf/ezmorph/primitive/ByteMorpher.java
@@ -16,9 +16,8 @@
 
 package net.sf.ezmorph.primitive;
 
+import java.util.Objects;
 import net.sf.ezmorph.MorphException;
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
 
 /**
  * Morphs to a byte.
@@ -54,12 +53,10 @@ public final class ByteMorpher extends AbstractIntegerMorpher {
         }
 
         ByteMorpher other = (ByteMorpher) obj;
-        EqualsBuilder builder = new EqualsBuilder();
         if (isUseDefault() && other.isUseDefault()) {
-            builder.append(getDefaultValue(), other.getDefaultValue());
-            return builder.isEquals();
+            return Objects.equals(getDefaultValue(), other.getDefaultValue());
         } else if (!isUseDefault() && !other.isUseDefault()) {
-            return builder.isEquals();
+            return true;
         } else {
             return false;
         }
@@ -74,11 +71,10 @@ public final class ByteMorpher extends AbstractIntegerMorpher {
 
     @Override
     public int hashCode() {
-        HashCodeBuilder builder = new HashCodeBuilder();
         if (isUseDefault()) {
-            builder.append(getDefaultValue());
+            return Objects.hashCode(getDefaultValue());
         }
-        return builder.toHashCode();
+        return 17;
     }
 
     /**

--- a/src/main/java/net/sf/ezmorph/primitive/CharMorpher.java
+++ b/src/main/java/net/sf/ezmorph/primitive/CharMorpher.java
@@ -16,9 +16,8 @@
 
 package net.sf.ezmorph.primitive;
 
+import java.util.Objects;
 import net.sf.ezmorph.MorphException;
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
 
 /**
  * Morphs to a char.
@@ -54,12 +53,10 @@ public final class CharMorpher extends AbstractPrimitiveMorpher {
         }
 
         CharMorpher other = (CharMorpher) obj;
-        EqualsBuilder builder = new EqualsBuilder();
         if (isUseDefault() && other.isUseDefault()) {
-            builder.append(getDefaultValue(), other.getDefaultValue());
-            return builder.isEquals();
+            return Objects.equals(getDefaultValue(), other.getDefaultValue());
         } else if (!isUseDefault() && !other.isUseDefault()) {
-            return builder.isEquals();
+            return true;
         } else {
             return false;
         }
@@ -74,11 +71,10 @@ public final class CharMorpher extends AbstractPrimitiveMorpher {
 
     @Override
     public int hashCode() {
-        HashCodeBuilder builder = new HashCodeBuilder();
         if (isUseDefault()) {
-            builder.append(getDefaultValue());
+            return Objects.hashCode(getDefaultValue());
         }
-        return builder.toHashCode();
+        return 17;
     }
 
     /**

--- a/src/main/java/net/sf/ezmorph/primitive/DoubleMorpher.java
+++ b/src/main/java/net/sf/ezmorph/primitive/DoubleMorpher.java
@@ -16,9 +16,8 @@
 
 package net.sf.ezmorph.primitive;
 
+import java.util.Objects;
 import net.sf.ezmorph.MorphException;
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
 
 /**
  * Morphs to a double.
@@ -54,12 +53,10 @@ public final class DoubleMorpher extends AbstractDecimalMorpher {
         }
 
         DoubleMorpher other = (DoubleMorpher) obj;
-        EqualsBuilder builder = new EqualsBuilder();
         if (isUseDefault() && other.isUseDefault()) {
-            builder.append(getDefaultValue(), other.getDefaultValue());
-            return builder.isEquals();
+            return Objects.equals(getDefaultValue(), other.getDefaultValue());
         } else if (!isUseDefault() && !other.isUseDefault()) {
-            return builder.isEquals();
+            return true;
         } else {
             return false;
         }
@@ -74,11 +71,10 @@ public final class DoubleMorpher extends AbstractDecimalMorpher {
 
     @Override
     public int hashCode() {
-        HashCodeBuilder builder = new HashCodeBuilder();
         if (isUseDefault()) {
-            builder.append(getDefaultValue());
+            return Objects.hashCode(getDefaultValue());
         }
-        return builder.toHashCode();
+        return 17;
     }
 
     /**

--- a/src/main/java/net/sf/ezmorph/primitive/FloatMorpher.java
+++ b/src/main/java/net/sf/ezmorph/primitive/FloatMorpher.java
@@ -16,9 +16,8 @@
 
 package net.sf.ezmorph.primitive;
 
+import java.util.Objects;
 import net.sf.ezmorph.MorphException;
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
 
 /**
  * Moprhs to a float.
@@ -54,12 +53,10 @@ public final class FloatMorpher extends AbstractDecimalMorpher {
         }
 
         FloatMorpher other = (FloatMorpher) obj;
-        EqualsBuilder builder = new EqualsBuilder();
         if (isUseDefault() && other.isUseDefault()) {
-            builder.append(getDefaultValue(), other.getDefaultValue());
-            return builder.isEquals();
+            return Objects.equals(getDefaultValue(), other.getDefaultValue());
         } else if (!isUseDefault() && !other.isUseDefault()) {
-            return builder.isEquals();
+            return true;
         } else {
             return false;
         }
@@ -74,11 +71,10 @@ public final class FloatMorpher extends AbstractDecimalMorpher {
 
     @Override
     public int hashCode() {
-        HashCodeBuilder builder = new HashCodeBuilder();
         if (isUseDefault()) {
-            builder.append(getDefaultValue());
+            return Objects.hashCode(getDefaultValue());
         }
-        return builder.toHashCode();
+        return 17;
     }
 
     /**

--- a/src/main/java/net/sf/ezmorph/primitive/IntMorpher.java
+++ b/src/main/java/net/sf/ezmorph/primitive/IntMorpher.java
@@ -16,9 +16,8 @@
 
 package net.sf.ezmorph.primitive;
 
+import java.util.Objects;
 import net.sf.ezmorph.MorphException;
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
 
 /**
  * Morphs to an int.
@@ -54,12 +53,10 @@ public final class IntMorpher extends AbstractIntegerMorpher {
         }
 
         IntMorpher other = (IntMorpher) obj;
-        EqualsBuilder builder = new EqualsBuilder();
         if (isUseDefault() && other.isUseDefault()) {
-            builder.append(getDefaultValue(), other.getDefaultValue());
-            return builder.isEquals();
+            return Objects.equals(getDefaultValue(), other.getDefaultValue());
         } else if (!isUseDefault() && !other.isUseDefault()) {
-            return builder.isEquals();
+            return true;
         } else {
             return false;
         }
@@ -74,11 +71,10 @@ public final class IntMorpher extends AbstractIntegerMorpher {
 
     @Override
     public int hashCode() {
-        HashCodeBuilder builder = new HashCodeBuilder();
         if (isUseDefault()) {
-            builder.append(getDefaultValue());
+            return Objects.hashCode(getDefaultValue());
         }
-        return builder.toHashCode();
+        return 17;
     }
 
     /**

--- a/src/main/java/net/sf/ezmorph/primitive/LongMorpher.java
+++ b/src/main/java/net/sf/ezmorph/primitive/LongMorpher.java
@@ -16,9 +16,8 @@
 
 package net.sf.ezmorph.primitive;
 
+import java.util.Objects;
 import net.sf.ezmorph.MorphException;
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
 
 /**
  * Morphs to a long.
@@ -54,12 +53,10 @@ public final class LongMorpher extends AbstractIntegerMorpher {
         }
 
         LongMorpher other = (LongMorpher) obj;
-        EqualsBuilder builder = new EqualsBuilder();
         if (isUseDefault() && other.isUseDefault()) {
-            builder.append(getDefaultValue(), other.getDefaultValue());
-            return builder.isEquals();
+            return Objects.equals(getDefaultValue(), other.getDefaultValue());
         } else if (!isUseDefault() && !other.isUseDefault()) {
-            return builder.isEquals();
+            return true;
         } else {
             return false;
         }
@@ -74,11 +71,10 @@ public final class LongMorpher extends AbstractIntegerMorpher {
 
     @Override
     public int hashCode() {
-        HashCodeBuilder builder = new HashCodeBuilder();
         if (isUseDefault()) {
-            builder.append(getDefaultValue());
+            return Objects.hashCode(getDefaultValue());
         }
-        return builder.toHashCode();
+        return 17;
     }
 
     /**

--- a/src/main/java/net/sf/ezmorph/primitive/ShortMorpher.java
+++ b/src/main/java/net/sf/ezmorph/primitive/ShortMorpher.java
@@ -15,9 +15,8 @@
  */
 package net.sf.ezmorph.primitive;
 
+import java.util.Objects;
 import net.sf.ezmorph.MorphException;
-import org.apache.commons.lang.builder.EqualsBuilder;
-import org.apache.commons.lang.builder.HashCodeBuilder;
 
 /**
  * Morphs to a short.
@@ -53,12 +52,10 @@ public final class ShortMorpher extends AbstractIntegerMorpher {
         }
 
         ShortMorpher other = (ShortMorpher) obj;
-        EqualsBuilder builder = new EqualsBuilder();
         if (isUseDefault() && other.isUseDefault()) {
-            builder.append(getDefaultValue(), other.getDefaultValue());
-            return builder.isEquals();
+            return Objects.equals(getDefaultValue(), other.getDefaultValue());
         } else if (!isUseDefault() && !other.isUseDefault()) {
-            return builder.isEquals();
+            return true;
         } else {
             return false;
         }
@@ -73,11 +70,10 @@ public final class ShortMorpher extends AbstractIntegerMorpher {
 
     @Override
     public int hashCode() {
-        HashCodeBuilder builder = new HashCodeBuilder();
         if (isUseDefault()) {
-            builder.append(getDefaultValue());
+            return Objects.hashCode(getDefaultValue());
         }
-        return builder.toHashCode();
+        return 17;
     }
 
     /**


### PR DESCRIPTION
Remove `EqualsBuilder` `HashCodeBuilder` usages, part of remove `commons-lang` deps.

Note: that not all `EqualsBuilder` `HashCodeBuilder` usages have been removed in this PR. Only the simple case of using defaultVaule as an equals judgment field has been removed.

This is intentional to simplify review difficulty of the PR. Complex usage will be further modified in subsequent PRs.

### Testing done

```
mvn clean verify
```

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->
