### PR TITLE
Remove Commons Logging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,36 +157,6 @@
       <version>3.2.2</version>
     </dependency>
     <dependency>
-      <groupId>commons-logging</groupId>
-      <artifactId>commons-logging</artifactId>
-      <version>1.3.5</version>
-      <exclusions>
-        <exclusion>
-          <groupId>avalon-framework</groupId>
-          <artifactId>avalon-framework</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>javax.servlet</groupId>
-          <artifactId>servlet-api</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>log4j</groupId>
-          <artifactId>log4j</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>logkit</groupId>
-          <artifactId>logkit</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
-      <version>1.2.17</version>
-      <scope>runtime</scope>
-      <optional>true</optional>
-    </dependency>
-    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
       <version>3.18.0</version>

--- a/src/main/java/net/sf/ezmorph/bean/BeanMorpher.java
+++ b/src/main/java/net/sf/ezmorph/bean/BeanMorpher.java
@@ -20,6 +20,8 @@ import java.beans.PropertyDescriptor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Collection;
 import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import net.sf.ezmorph.MorphException;
 import net.sf.ezmorph.MorpherRegistry;
 import net.sf.ezmorph.ObjectMorpher;
@@ -27,8 +29,6 @@ import net.sf.ezmorph.object.IdentityObjectMorpher;
 import org.apache.commons.beanutils.DynaBean;
 import org.apache.commons.beanutils.DynaProperty;
 import org.apache.commons.beanutils.PropertyUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 
 /**
  * Converts a JavaBean into another JavaBean or DynaBean.<br>
@@ -42,7 +42,7 @@ import org.apache.commons.logging.LogFactory;
  * @author Andres Almiray <a href="mailto:aalmiray@users.sourceforge.net">aalmiray@users.sourceforge.net</a>
  */
 public final class BeanMorpher implements ObjectMorpher {
-    private static final Log log = LogFactory.getLog(BeanMorpher.class);
+    private static final Logger logger = Logger.getLogger(BeanMorpher.class.getName());
     private final Class beanClass;
     private boolean lenient;
     private final MorpherRegistry morpherRegistry;
@@ -89,7 +89,9 @@ public final class BeanMorpher implements ObjectMorpher {
             for (PropertyDescriptor targetPd : targetPds) {
                 String name = targetPd.getName();
                 if (targetPd.getWriteMethod() == null) {
-                    log.info("Property '" + beanClass.getName() + "." + name + "' has no write method. SKIPPED.");
+                    logger.log(
+                            Level.INFO,
+                            "Property '" + beanClass.getName() + "." + name + "' has no write method. SKIPPED.");
                     continue;
                 }
 
@@ -98,19 +100,23 @@ public final class BeanMorpher implements ObjectMorpher {
                     DynaBean dynaBean = (DynaBean) sourceBean;
                     DynaProperty dynaProperty = dynaBean.getDynaClass().getDynaProperty(name);
                     if (dynaProperty == null) {
-                        log.warn("DynaProperty '" + name + "' does not exist. SKIPPED.");
+                        logger.log(Level.WARNING, "DynaProperty '" + name + "' does not exist. SKIPPED.");
                         continue;
                     }
                     sourceType = dynaProperty.getType();
                 } else {
                     PropertyDescriptor sourcePd = PropertyUtils.getPropertyDescriptor(sourceBean, name);
                     if (sourcePd == null) {
-                        log.warn("Property '" + sourceBean.getClass().getName() + "." + name
-                                + "' does not exist. SKIPPED.");
+                        logger.log(
+                                Level.WARNING,
+                                "Property '" + sourceBean.getClass().getName() + "." + name
+                                        + "' does not exist. SKIPPED.");
                         continue;
                     } else if (sourcePd.getReadMethod() == null) {
-                        log.warn("Property '" + sourceBean.getClass().getName() + "." + name
-                                + "' has no read method. SKIPPED.");
+                        logger.log(
+                                Level.WARNING,
+                                "Property '" + sourceBean.getClass().getName() + "." + name
+                                        + "' has no read method. SKIPPED.");
                         continue;
                     }
                     sourceType = sourcePd.getPropertyType();
@@ -161,8 +167,10 @@ public final class BeanMorpher implements ObjectMorpher {
                             throw new MorphException("Can't find a morpher for target class " + targetType.getName()
                                     + " (" + name + ")");
                         } else {
-                            log.info("Can't find a morpher for target class " + targetType.getName() + " (" + name
-                                    + ") SKIPPED");
+                            logger.log(
+                                    Level.INFO,
+                                    "Can't find a morpher for target class " + targetType.getName() + " (" + name
+                                            + ") SKIPPED");
                         }
                     } else {
                         PropertyUtils.setProperty(targetBean, name, morpherRegistry.morph(targetType, value));

--- a/src/main/java/net/sf/json/AbstractJSON.java
+++ b/src/main/java/net/sf/json/AbstractJSON.java
@@ -23,10 +23,10 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import net.sf.json.util.JSONUtils;
 import net.sf.json.util.JsonEventListener;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 
 /**
  * Base class for JSONObject and JSONArray.
@@ -52,7 +52,7 @@ abstract class AbstractJSON implements JSON {
 
     private static CycleSet cycleSet = new CycleSet();
 
-    private static final Log log = LogFactory.getLog(AbstractJSON.class);
+    private static final Logger logger = Logger.getLogger(AbstractJSON.class.getName());
 
     /**
      * Adds a reference for cycle detection check.
@@ -75,7 +75,7 @@ abstract class AbstractJSON implements JSON {
                 try {
                     listener.onArrayEnd();
                 } catch (RuntimeException e) {
-                    log.warn(e);
+                    logger.log(Level.WARNING, e.getMessage(), e);
                 }
             }
         }
@@ -91,7 +91,7 @@ abstract class AbstractJSON implements JSON {
                 try {
                     listener.onArrayStart();
                 } catch (RuntimeException e) {
-                    log.warn(e);
+                    logger.log(Level.WARNING, e.getMessage(), e);
                 }
             }
         }
@@ -110,7 +110,7 @@ abstract class AbstractJSON implements JSON {
                 try {
                     listener.onElementAdded(index, element);
                 } catch (RuntimeException e) {
-                    log.warn(e);
+                    logger.log(Level.WARNING, e.getMessage(), e);
                 }
             }
         }
@@ -128,7 +128,7 @@ abstract class AbstractJSON implements JSON {
                 try {
                     listener.onError(jsone);
                 } catch (RuntimeException e) {
-                    log.warn(e);
+                    logger.log(Level.WARNING, e.getMessage(), e);
                 }
             }
         }
@@ -144,7 +144,7 @@ abstract class AbstractJSON implements JSON {
                 try {
                     listener.onObjectEnd();
                 } catch (RuntimeException e) {
-                    log.warn(e);
+                    logger.log(Level.WARNING, e.getMessage(), e);
                 }
             }
         }
@@ -160,7 +160,7 @@ abstract class AbstractJSON implements JSON {
                 try {
                     listener.onObjectStart();
                 } catch (RuntimeException e) {
-                    log.warn(e);
+                    logger.log(Level.WARNING, e.getMessage(), e);
                 }
             }
         }
@@ -180,7 +180,7 @@ abstract class AbstractJSON implements JSON {
                 try {
                     listener.onPropertySet(key, value, accumulated);
                 } catch (RuntimeException e) {
-                    log.warn(e);
+                    logger.log(Level.WARNING, e.getMessage(), e);
                 }
             }
         }
@@ -198,7 +198,7 @@ abstract class AbstractJSON implements JSON {
                 try {
                     listener.onWarning(warning);
                 } catch (RuntimeException e) {
-                    log.warn(e);
+                    logger.log(Level.WARNING, e.getMessage(), e);
                 }
             }
         }

--- a/src/main/java/net/sf/json/JSONObject.java
+++ b/src/main/java/net/sf/json/JSONObject.java
@@ -34,6 +34,8 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.regex.Pattern;
 import net.sf.ezmorph.Morpher;
 import net.sf.ezmorph.array.ObjectArrayMorpher;
@@ -52,8 +54,6 @@ import net.sf.json.util.PropertySetStrategy;
 import org.apache.commons.beanutils.DynaBean;
 import org.apache.commons.beanutils.DynaProperty;
 import org.apache.commons.beanutils.PropertyUtils;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 
 /**
  * A JSONObject is an unordered collection of name/value pairs. Its external
@@ -112,7 +112,7 @@ import org.apache.commons.logging.LogFactory;
  */
 public final class JSONObject extends AbstractJSON implements JSON, Map<String, Object>, Comparable {
 
-    private static final Log log = LogFactory.getLog(JSONObject.class);
+    private static final Logger logger = Logger.getLogger(JSONObject.class.getName());
 
     /**
      * Creates a JSONObject.<br>
@@ -201,7 +201,7 @@ public final class JSONObject extends AbstractJSON implements JSON, Map<String, 
                 } else {
                     if (type.isPrimitive()) {
                         // assume assigned default value
-                        log.warn("Tried to assign null value to " + key + ":" + type.getName());
+                        logger.log(Level.WARNING, "Tried to assign null value to " + key + ":" + type.getName());
                         dynaBean.set(key, JSONUtils.getMorpherRegistry().morph(type, null));
                     } else {
                         dynaBean.set(key, null);
@@ -475,7 +475,9 @@ public final class JSONObject extends AbstractJSON implements JSON, Map<String, 
                 Property pd = getProperty(rootClass, bean, key, jsonConfig);
                 if (pd != null) {
                     if (!pd.isWritable()) {
-                        log.info("Property '" + key + "' of " + bean.getClass() + " has no write method. SKIPPED.");
+                        logger.log(
+                                Level.INFO,
+                                "Property '" + key + "' of " + bean.getClass() + " has no write method. SKIPPED.");
                         continue;
                     }
                     if (jsonConfig.getPropertySetStrategy() != null) {
@@ -518,8 +520,10 @@ public final class JSONObject extends AbstractJSON implements JSON, Map<String, 
                             } else if (beanClass == null || bean instanceof Map) {
                                 pd.set(bean, value, jsonConfig);
                             } else {
-                                log.warn("Tried to assign property " + key + ":" + type.getName() + " to bean of class "
-                                        + bean.getClass().getName());
+                                logger.log(
+                                        Level.WARNING,
+                                        "Tried to assign property " + key + ":" + type.getName() + " to bean of class "
+                                                + bean.getClass().getName());
                             }
                         } else {
                             if (jsonConfig.isHandleJettisonSingleElementArray()) {
@@ -557,7 +561,7 @@ public final class JSONObject extends AbstractJSON implements JSON, Map<String, 
                     } else {
                         if (type.isPrimitive()) {
                             // assume assigned default value
-                            log.warn("Tried to assign null value to " + key + ":" + type.getName());
+                            logger.log(Level.WARNING, "Tried to assign null value to " + key + ":" + type.getName());
                             pd.set(bean, JSONUtils.getMorpherRegistry().morph(type, null), jsonConfig);
                         } else {
                             pd.set(bean, null, jsonConfig);
@@ -582,8 +586,10 @@ public final class JSONObject extends AbstractJSON implements JSON, Map<String, 
                                     || !jsonConfig.isIgnorePublicFields()) {
                                 setProperty(bean, name, value, jsonConfig);
                             } else {
-                                log.warn("Tried to assign property " + key + ":" + type.getName() + " to bean of class "
-                                        + bean.getClass().getName());
+                                logger.log(
+                                        Level.WARNING,
+                                        "Tried to assign property " + key + ":" + type.getName() + " to bean of class "
+                                                + bean.getClass().getName());
                             }
                         } else {
                             if (jsonConfig.isHandleJettisonSingleElementArray()) {
@@ -599,7 +605,7 @@ public final class JSONObject extends AbstractJSON implements JSON, Map<String, 
                     } else {
                         if (type.isPrimitive()) {
                             // assume assigned default value
-                            log.warn("Tried to assign null value to " + key + ":" + type.getName());
+                            logger.log(Level.WARNING, "Tried to assign null value to " + key + ":" + type.getName());
                             setProperty(
                                     bean, name, JSONUtils.getMorpherRegistry().morph(type, null), jsonConfig);
                         } else {
@@ -702,7 +708,7 @@ public final class JSONObject extends AbstractJSON implements JSON, Map<String, 
                     // bug 2565295
                     String warning = "Property '" + key + "' of " + beanClass + " has no read method. SKIPPED";
                     fireWarnEvent(warning, jsonConfig);
-                    log.info(warning);
+                    logger.log(Level.INFO, warning);
                     continue;
                 }
                 if (pd.getReadMethod() != null) {
@@ -742,7 +748,7 @@ public final class JSONObject extends AbstractJSON implements JSON, Map<String, 
                 } else {
                     String warning = "Property '" + key + "' of " + beanClass + " has no read method. SKIPPED";
                     fireWarnEvent(warning, jsonConfig);
-                    log.info(warning);
+                    logger.log(Level.INFO, warning);
                 }
             }
             // inspect public fields, this operation may fail under
@@ -786,7 +792,7 @@ public final class JSONObject extends AbstractJSON implements JSON, Map<String, 
                     }
                 }
             } catch (Exception e) {
-                log.trace("Couldn't read public fields.", e);
+                logger.log(Level.FINEST, "Couldn't read public fields.", e);
             }
         } catch (JSONException jsone) {
             removeInstance(bean);
@@ -1225,7 +1231,8 @@ public final class JSONObject extends AbstractJSON implements JSON, Map<String, 
         try {
             return isTransientField(beanClass.getDeclaredField(name), jsonConfig);
         } catch (Exception e) {
-            log.info("Error while inspecting field " + beanClass + "." + name + " for transient status.", e);
+            logger.log(
+                    Level.INFO, "Error while inspecting field " + beanClass + "." + name + " for transient status.", e);
         }
         return false;
     }
@@ -1237,7 +1244,7 @@ public final class JSONObject extends AbstractJSON implements JSON, Map<String, 
             }
             return isTransient(field, jsonConfig);
         } catch (Exception e) {
-            log.info("Error while inspecting field " + field + " for transient status.", e);
+            logger.log(Level.INFO, "Error while inspecting field " + field + " for transient status.", e);
         }
         return false;
     }
@@ -1250,7 +1257,7 @@ public final class JSONObject extends AbstractJSON implements JSON, Map<String, 
                     return true;
                 }
             } catch (Exception e) {
-                log.info("Error while inspecting " + element + " for transient status.", e);
+                logger.log(Level.INFO, "Error while inspecting " + element + " for transient status.", e);
             }
         }
         return false;
@@ -1259,8 +1266,10 @@ public final class JSONObject extends AbstractJSON implements JSON, Map<String, 
     private static Object morphPropertyValue(String key, Object value, Class type, Class targetType) {
         Morpher morpher = JSONUtils.getMorpherRegistry().getMorpherFor(targetType);
         if (IdentityObjectMorpher.getInstance().equals(morpher)) {
-            log.warn("Can't transform property '" + key + "' from " + type.getName() + " into " + targetType.getName()
-                    + ". Will register a default Morpher");
+            logger.log(
+                    Level.WARNING,
+                    "Can't transform property '" + key + "' from " + type.getName() + " into " + targetType.getName()
+                            + ". Will register a default Morpher");
             if (Enum.class.isAssignableFrom(targetType)) {
                 JSONUtils.getMorpherRegistry().registerMorpher(new EnumMorpher(targetType));
             } else {

--- a/src/site/xdoc/index.xml
+++ b/src/site/xdoc/index.xml
@@ -53,10 +53,8 @@
       </p>
       <p>Json-lib requires (at least) the following dependencies in your classpath:
          <ul>
-            <li>jakarta commons-lang 2.5</li>
             <li>jakarta commons-beanutils 1.8.0</li>
             <li>jakarta commons-collections 3.2.1</li>
-            <li>jakarta commons-logging 1.1.1</li>
             <li>ezmorph 1.0.6</li>
          </ul>
       </p>


### PR DESCRIPTION
Jenkins core generally prefers to use JUL rather than third-party libraries like Commons Logging.