### PR TITLE
Reduce usage of Commons Collections

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -152,11 +152,6 @@
       <version>1.11.0</version>
     </dependency>
     <dependency>
-      <groupId>commons-collections</groupId>
-      <artifactId>commons-collections</artifactId>
-      <version>3.2.2</version>
-    </dependency>
-    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
       <version>3.18.0</version>

--- a/src/site/xdoc/index.xml
+++ b/src/site/xdoc/index.xml
@@ -54,7 +54,6 @@
       <p>Json-lib requires (at least) the following dependencies in your classpath:
          <ul>
             <li>jakarta commons-beanutils 1.8.0</li>
-            <li>jakarta commons-collections 3.2.1</li>
             <li>ezmorph 1.0.6</li>
          </ul>
       </p>


### PR DESCRIPTION
This direct dependency seemed gratuitous. We still pull in Commons Collections transitively through Commons BeanUtils, but at least we don't use it ourselves anymore.